### PR TITLE
Pass country code to iTunes Search API

### DIFF
--- a/src/itunes-search.coffee
+++ b/src/itunes-search.coffee
@@ -11,11 +11,13 @@ module.exports = (robot) ->
 
   robot.respond /music( me)? (.+)/i, (msg) ->
     query = msg.match[2]
+    country = process.env.HUBOT_ITUNES_SEARCH_COUNTRY || 'US'
     robot.http("http://itunes.apple.com/search")
       .query({
         entity: "song",
         limit: "1",
-        term: query
+        term: query,
+        country: country
       })
       .get() (err, res, body) ->
 


### PR DESCRIPTION
Hi, I'm an engineer in Japan and using this library. But the search result URL looks like available only in US.
So I added a feature that user can set country code via `HUBOT_ITUNES_SEARCH_COUNTRY`.
Would you please merge this? @jonrohan 